### PR TITLE
fix(project, recruitment): th to st, nd, rd, th

### DIFF
--- a/components/project/project/card.vue
+++ b/components/project/project/card.vue
@@ -10,7 +10,7 @@
     >
       <img class="thumbnail" :data-src="thumbnail" v-lazy-load />
       <p class="name">{{ project.app_name }}</p>
-      <p class="time">{{ project.th }}th | {{ project.year }}</p>
+      <p class="time">{{ project.th }}{{ project.th % 10 === 1? 'st': project.th % 10 === 2? 'nd': project.th % 10 === 3? 'rd': 'th' }} | {{ project.year }}</p>
     </nuxt-link>
     <div class="links">
       <div

--- a/components/project/project/card.vue
+++ b/components/project/project/card.vue
@@ -10,7 +10,7 @@
     >
       <img class="thumbnail" :data-src="thumbnail" v-lazy-load />
       <p class="name">{{ project.app_name }}</p>
-      <p class="time">{{ project.th }}{{ project.th % 10 === 1? 'st': project.th % 10 === 2? 'nd': project.th % 10 === 3? 'rd': 'th' }} | {{ project.year }}</p>
+      <p class="time">{{ project.th }}{{ th_text }} | {{ project.year }}</p>
     </nuxt-link>
     <div class="links">
       <div
@@ -42,6 +42,18 @@ const ProjectCard = defineComponent({
   computed: {
     thumbnail() {
       return this.project.thumbnail || "/no-image.svg";
+    },
+    th_text() {
+      const last_digit = this.project.th % 10;
+      if (last_digit === 1) {
+        return 'st';
+      } else if (last_digit === 2) {
+        return 'nd';
+      } else if (last_digit === 3) {
+        return 'rd';
+      } else {
+        return 'th';
+      }
     },
   },
   methods: {

--- a/components/project/project/detail.vue
+++ b/components/project/project/detail.vue
@@ -16,7 +16,7 @@
       <div class="contents">
         <div class="information">
           <h1 class="name">{{ project.app_name }}</h1>
-          <div class="th-year">{{ project.th }}th | {{ project.year }}</div>
+          <div class="th-year">{{ project.th }}{{ project.th % 10 === 1? 'st': project.th % 10 === 2? 'nd': project.th % 10 === 3? 'rd': 'th' }} | {{ project.year }}</div>
           <div class="team-members">
             TEAM {{ project.team_name }} | {{ members }}
           </div>

--- a/components/project/project/detail.vue
+++ b/components/project/project/detail.vue
@@ -16,7 +16,7 @@
       <div class="contents">
         <div class="information">
           <h1 class="name">{{ project.app_name }}</h1>
-          <div class="th-year">{{ project.th }}{{ project.th % 10 === 1? 'st': project.th % 10 === 2? 'nd': project.th % 10 === 3? 'rd': 'th' }} | {{ project.year }}</div>
+          <div class="th-year">{{ project.th }}{{ th_text }} | {{ project.year }}</div>
           <div class="team-members">
             TEAM {{ project.team_name }} | {{ members }}
           </div>
@@ -68,6 +68,18 @@ export default defineComponent({
     },
     thumbnail() {
       return this.project.thumbnail || "/no-image.svg";
+    },
+    th_text() {
+      const last_digit = this.project.th % 10;
+      if (last_digit === 1) {
+        return 'st';
+      } else if (last_digit === 2) {
+        return 'nd';
+      } else if (last_digit === 3) {
+        return 'rd';
+      } else {
+        return 'th';
+      }
     },
   },
   methods: {

--- a/pages/recruitment.vue
+++ b/pages/recruitment.vue
@@ -211,7 +211,7 @@ export default defineComponent({
     is_recruiting() {
       return this.s_day <= 0 && this.d_day >= 0;
     },
-    getTh() {
+    th_text() {
       const last_digit = this.banner.th % 10;
       if (last_digit === 1) {
         return 'st';
@@ -232,7 +232,7 @@ export default defineComponent({
         }
         case "NOTICE":
         case "PROGRESS": {
-          return `NEXTERS ${th}${ this.getTh }\nRecruitment`;
+          return `NEXTERS ${th}${this.th_text}\nRecruitment`;
         }
       }
       return "";

--- a/pages/recruitment.vue
+++ b/pages/recruitment.vue
@@ -211,6 +211,18 @@ export default defineComponent({
     is_recruiting() {
       return this.s_day <= 0 && this.d_day >= 0;
     },
+    getTh() {
+      const last_digit = this.banner.th % 10;
+      if (last_digit === 1) {
+        return 'st';
+      } else if (last_digit === 2) {
+        return 'nd';
+      } else if (last_digit === 3) {
+        return 'rd';
+      } else {
+        return 'th';
+      }
+    },
   },
   methods: {
     makeBannerTitle(type, th) {
@@ -220,7 +232,7 @@ export default defineComponent({
         }
         case "NOTICE":
         case "PROGRESS": {
-          return `NEXTERS ${th}${ th % 10 === 1? 'st': th % 10 === 2? 'nd': th % 10 === 3? 'rd': 'th' }\nRecruitment`;
+          return `NEXTERS ${th}${ this.getTh }\nRecruitment`;
         }
       }
       return "";

--- a/pages/recruitment.vue
+++ b/pages/recruitment.vue
@@ -220,7 +220,7 @@ export default defineComponent({
         }
         case "NOTICE":
         case "PROGRESS": {
-          return `NEXTERS ${th}th\nRecruitment`;
+          return `NEXTERS ${th}${ th % 10 === 1? 'st': th % 10 === 2? 'nd': th % 10 === 3? 'rd': 'th' }\nRecruitment`;
         }
       }
       return "";


### PR DESCRIPTION
# Summary
`n번째 기수`에서 ~번째 해당하는 단어를 수정한다.
   + 1로 끝나는 기수는 `st`로 수정
   + 2로 끝나는 기수는 `nd`로 수정
   + 3으로 끝나는 기수는 `rd`로 수정
   + 나머지 기수는 `th`로 수정

# Issue
- #12 

---

<details>
<summary>변경 전</summary>
<img src="https://user-images.githubusercontent.com/60142959/233853491-bae7300e-8016-4c3f-82d5-4baa9400d725.png" alt="변경 전 recruitment"/>
<img src="https://user-images.githubusercontent.com/60142959/233757878-3edd2245-6090-438f-be06-6f77e7cbb0ad.png" alt="변경 전 project"/>
</details>

<details>
<summary>변경 후</summary>
<img src="https://user-images.githubusercontent.com/60142959/233853702-95f63430-0185-47e8-8231-83840aa659f4.png" alt="변경 후 recruitment"/>
<img src="https://user-images.githubusercontent.com/60142959/233853690-bbeebbcd-c6c7-4a5f-b212-c58ebff3634e.png" alt="변경 후 project"/>
</details>