### PR TITLE
fix(recruitment): hide d-day before recruitment

### DIFF
--- a/components/recruitment/banner.vue
+++ b/components/recruitment/banner.vue
@@ -62,7 +62,7 @@ export default defineComponent({
   },
   computed: {
     isVisibleDate() {
-      return this.type !== "DEFAULT";
+      return this.type === "PROGRESS";
     },
     badgeText() {
       return this.remainingPeriod > 0


### PR DESCRIPTION
# Summary
d-day가 모집 기간 이전에 노출되는 문제 해결

# Issue
- close #6 

<details>
<summary>변경 전</summary>
<img src="https://user-images.githubusercontent.com/60142959/234027154-b6dba68d-8380-4a78-b624-917c88abac9c.png" alt="변경 전 recruitment"/>
</details>
<details>
<summary>변경 후</summary>
<img src="https://user-images.githubusercontent.com/60142959/234027344-be888501-8ebe-48e7-903c-98e1fc0f4dde.png" alt="변경 후 recruitment"/>
</details>