### PR TITLE
feat(footer): add sponsor banner

### DIFF
--- a/components/footer.vue
+++ b/components/footer.vue
@@ -32,6 +32,9 @@
             </ul>
           </div>
         </div>
+        <div class="sba-promotion" v-show="isShowSbaBanner">
+          <img src="https://drive.google.com/uc?export=view&id=1Gtxu9vrt_tUDQCC_XXvDQhYXAmP4izCu" class="sba-img" size="100%" @click="linkToSeSacThon"/>
+        </div>
         <div class="sponsorGuideText">
           본 페이지는 Naver Cloud Platform 서버 지원으로 운영되고 있습니다. @NEXTERS 2021
         </div>
@@ -74,6 +77,7 @@ export default defineComponent({
   data() {
     return {
       isSponsorVisible: false,
+      isShowSbaBanner: this.$route.path !== '/',
     };
   },
   methods: {
@@ -83,6 +87,9 @@ export default defineComponent({
     icon(item) {
       return this.isWhite ? item.white : item.black;
     },
+    linkToSeSacThon() {
+      window.location.href = "https://sesacthon-apply.goorm.io";
+    }
   },
 });
 </script>
@@ -324,6 +331,32 @@ footer {
       .sponsorItem {
         font-size: 14px;
         line-height: 21px;
+      }
+    }
+  }
+
+  .sba-promotion {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: start;
+    grid-gap: 2.666666666666667vw;
+    padding-bottom: 2.666666666666667vw;
+
+    .sba-img {
+      width: 378px;
+      height: 164px;
+      cursor: pointer;
+
+      @include tablet {
+        width: 35.26119402985075vw;
+        height: 15.29850746268657vw;
+      }
+
+      @include mobile {
+        width: 42.30769230769231vw;
+        height: 18.35641025641026vw;
       }
     }
   }

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -33,7 +33,9 @@
           </div>
         </div>
         <div class="sba-promotion" v-show="isShowSbaBanner">
-          <img src="https://drive.google.com/uc?export=view&id=1Gtxu9vrt_tUDQCC_XXvDQhYXAmP4izCu" class="sba-img" size="100%" @click="linkToSeSacThon"/>
+          <a href="https://sesacthon-apply.goorm.io" target="_blank">
+            <img src="https://drive.google.com/uc?export=view&id=1Gtxu9vrt_tUDQCC_XXvDQhYXAmP4izCu" class="sba-img" size="100%" @click="linkToSeSacThon"/>
+          </a>
         </div>
         <div class="sponsorGuideText">
           본 페이지는 Naver Cloud Platform 서버 지원으로 운영되고 있습니다. @NEXTERS 2021
@@ -87,9 +89,6 @@ export default defineComponent({
     icon(item) {
       return this.isWhite ? item.white : item.black;
     },
-    linkToSeSacThon() {
-      window.location.href = "https://sesacthon-apply.goorm.io";
-    }
   },
 });
 </script>
@@ -347,7 +346,6 @@ footer {
     .sba-img {
       width: 378px;
       height: 164px;
-      cursor: pointer;
 
       @include tablet {
         width: 35.26119402985075vw;

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -34,7 +34,7 @@
         </div>
         <div class="sba-promotion" v-show="isShowSbaBanner">
           <a href="https://sesacthon-apply.goorm.io" target="_blank">
-            <img src="https://drive.google.com/uc?export=view&id=1Gtxu9vrt_tUDQCC_XXvDQhYXAmP4izCu" class="sba-img" size="100%" @click="linkToSeSacThon"/>
+            <img src="https://drive.google.com/uc?export=view&id=1Gtxu9vrt_tUDQCC_XXvDQhYXAmP4izCu" class="sba-img" size="100%"/>
           </a>
         </div>
         <div class="sponsorGuideText">


### PR DESCRIPTION
# Summary
SBA SaSAC 배너를 footer에 추가합니다.
+ 이미 배너로 덮여있는 main 화면은 제외합니다.
+ 배너 클릭 시 [새싹톤 페이지](https://sesacthon-apply.goorm.io)로 이동합니다.
+ 이미지는 구글 드라이브에 업로드하였고, id 값을 활용하였습니다.
+ pc에서의 사진은 고정, 나머지는 화면 크기에 맞게 표시됩니다.

# Issue
- close #28 

# Changelog

---

<details>
<summary>PC</summary>
<img src="https://user-images.githubusercontent.com/60142959/236409393-d92cbba4-3985-4964-926f-8849d4c1e6df.png" alt="pc"/>
</details>
<details>
<summary>Tablet</summary>
<img src="https://user-images.githubusercontent.com/60142959/236410020-781800d7-fbf2-4dc5-a82c-7e5075648132.png" alt="tablet"/>
</details>
<details>
<summary>Mobile</summary>
<img src="https://user-images.githubusercontent.com/60142959/236389191-3ea6ce73-aa5f-483c-8a0f-4ad08714ea22.png" alt="mobile"/>
</details>