### PR TITLE
fix(about, project, recruitment, footer, contact): fix link to open on a new page

### DIFF
--- a/components/about/review/card.vue
+++ b/components/about/review/card.vue
@@ -19,7 +19,7 @@ const ReviewCard = defineComponent({
   },
   methods: {
     onClick: function () {
-      window.location.href = this.href;
+      window.open(this.href);
     },
   },
 });

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -16,7 +16,7 @@
                     :key="sponsor.idx"
                     class="sponsorItem"
                   >
-                    <a :href="sponsor.href">
+                    <a :href="sponsor.href" target="_blank">
                       <span>{{ sponsor.name }}</span>
                     </a>
                   </section>
@@ -26,7 +26,7 @@
           </div>
           <div class="sns">
             <ul v-for="item in items" v-show="item.visible" :key="item.idx">
-              <a :href="item.href">
+              <a :href="item.href" target="_blank">
                 <img :src="icon(item)" :alt="item.name" />
               </a>
             </ul>

--- a/components/project/project/card.vue
+++ b/components/project/project/card.vue
@@ -20,7 +20,7 @@
         @click="onClickLink(link)"
         @click.stop=""
       >
-        <a :href="link">
+        <a :href="link" target="_blank">
           {{ platform }}
         </a>
       </div>
@@ -59,7 +59,7 @@ const ProjectCard = defineComponent({
   methods: {
     ...mapActions({ showDetail: "project/showDetail" }),
     onClickLink(href) {
-      window.location.href = href;
+      window.open(href);
     },
     scrollToId(id) {
       document.getElementById(id).scrollIntoView();

--- a/components/project/project/detail.vue
+++ b/components/project/project/detail.vue
@@ -37,6 +37,7 @@
           :key="platform"
           class="link-item"
           :href="link"
+          target="_blank"
         >
           {{ platform }}
         </a>

--- a/components/recruitment/banner.vue
+++ b/components/recruitment/banner.vue
@@ -19,6 +19,7 @@
           class="box"
           :button-name="box.name"
           :href="`${box.link}`"
+          :is-new-page=true
         />
       </article>
     </div>

--- a/components/recruitment/linkButton.vue
+++ b/components/recruitment/linkButton.vue
@@ -28,7 +28,7 @@ export default defineComponent({
     },
     isNewPage: {
       type: Boolean,
-      require: false,
+      require: true,
     }
   },
   methods: {

--- a/components/recruitment/linkButton.vue
+++ b/components/recruitment/linkButton.vue
@@ -26,10 +26,18 @@ export default defineComponent({
       type: String,
       require: false,
     },
+    isNewPage: {
+      type: Boolean,
+      require: false,
+    }
   },
   methods: {
     onClick: function () {
-      location.href = this.href;
+      if (this.isNewPage) {
+        window.open(this.href);
+      } else {
+        location.href = this.href;
+      }
     },
   },
 });

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -72,11 +72,11 @@ export default defineComponent({
     handleClick: (action) => () => {
       switch (action) {
         case "kakao": {
-          window.location.href = "https://pf.kakao.com/_xdxmnnj";
+          window.open("https://pf.kakao.com/_xdxmnnj");
           break;
         }
         case "facebook": {
-          window.location.href = "https://www.facebook.com/Nexterspage";
+          window.open("https://www.facebook.com/Nexterspage");
           break;
         }
         case "gmail": {

--- a/pages/recruitment.vue
+++ b/pages/recruitment.vue
@@ -37,6 +37,7 @@
           class="faqBox"
           :button-name="`FAQ 바로가기`"
           :href="`/contact#faq`"
+          :is-new-page=false
         />
       </div>
     </div>


### PR DESCRIPTION
# Summary
다른 페이지로 이동하는 링크들을 새 창에서 열리도록 수정했습니다.
- 관련 페이지
  - About
     - 기존회원의 블로그 후기글
  - Recruitment
     - `신입회원 지원하기` or `모집 알림 신청하기` 버튼
  - Footer
     - `Sponsored by` 스폰서 목록
     - sns 목록
  - Contact
     - Contact Us에 연결된 링크들
- `<a>` 태그를 사용한 코드는 `target="_blank"`를 추가했습니다.
- `location.href`를 사용한 코드는 `window.open(link)`로 수정했습니다.

페이지 내 이동은 현재 창에서 이동합니다.
  - `recruitment` 페이지 내 버튼들이 동일하게 LinkButton을 사용하고 있어 isNewPage 변수를 추가했습니다.
  - 지원하기, 신청하기 버튼은 새 창에서, FAQ 바로가기 버튼은 현재 창에서 열립니다.

# Issue
- close #30 
