### PR TITLE
fix(contact): applying removed informations (#36)

### DIFF
--- a/content_generator/_utils.py
+++ b/content_generator/_utils.py
@@ -1,5 +1,6 @@
 import json
 from os import remove, listdir
+import re
 from typing import List
 
 GoogleSheetResult = List[List[str]]
@@ -295,8 +296,10 @@ def make_contacts(contact_us: GoogleSheetResult, faq: GoogleSheetResult) -> None
         }
         _faqs.append(_faq)
         
+    content_file_pattern = re.compile("[0-9]+\.json")
+    
     for filename in listdir("./content/contacts"):
-        if filename.endswith(".json"):
+        if content_file_pattern.match(filename):
             remove(f"./content/contacts/{filename}")
 
     for idx, _contact in enumerate(_contacts):
@@ -304,7 +307,7 @@ def make_contacts(contact_us: GoogleSheetResult, faq: GoogleSheetResult) -> None
             f.write(json.dumps(_contact, ensure_ascii=False, indent=2))
             
     for filename in listdir("./content/contacts/faq"):
-        if filename.endswith(".json"):
+        if content_file_pattern.match(filename):
             remove(f"./content/contacts/faq/{filename}")
 
     for idx, _faq in enumerate(_faqs):

--- a/content_generator/_utils.py
+++ b/content_generator/_utils.py
@@ -1,4 +1,5 @@
 import json
+from os import remove, listdir
 from typing import List
 
 GoogleSheetResult = List[List[str]]
@@ -293,10 +294,18 @@ def make_contacts(contact_us: GoogleSheetResult, faq: GoogleSheetResult) -> None
             "answer": answer
         }
         _faqs.append(_faq)
+        
+    for filename in listdir("./content/contacts"):
+        if filename.endswith(".json"):
+            remove(f"./content/contacts/{filename}")
 
     for idx, _contact in enumerate(_contacts):
         with open(f"./content/contacts/{idx}.json", mode="w", encoding="utf-8") as f:
             f.write(json.dumps(_contact, ensure_ascii=False, indent=2))
+            
+    for filename in listdir("./content/contacts/faq"):
+        if filename.endswith(".json"):
+            remove(f"./content/contacts/faq/{filename}")
 
     for idx, _faq in enumerate(_faqs):
         with open(f"./content/contacts/faq/{idx}.json", mode="w", encoding="utf-8") as f:


### PR DESCRIPTION
# Summary
시트에서 FAQ와 CONTACT를 삭제하고 docker-compose up content-updater 커맨드를 실행하여도 정보 삭제가 반영되지 않는 이슈를 수정했습니다.

CONTACT, FAQ 정보를 풀러와서 json 파일을 작성하기 전, 레거시 파일들을 삭제하는 로직을 추가함으로써 문제를 해결했습니다.

# Issue
#36 

# Changelog

---

<details open> <summary>스크린샷</summary>

</details>