### PR TITLE
fix(contact): change instagram URL into ID (#39)

### DIFF
--- a/components/contact/contactBox.vue
+++ b/components/contact/contactBox.vue
@@ -47,7 +47,7 @@ export default defineComponent({
         instagram: {
           icon: require("~/assets/img/instagram.svg"),
           iconText: "Instagram",
-          text: "https://www.instagram.com/team_nexters/",
+          text: "@team_nexters",
           link: "",
         },
       },

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -89,6 +89,10 @@ export default defineComponent({
           alert("'teamnexters@gmail.com' 메일 주소를 복사했습니다. ");
           break;
         }
+        case "instagram": {
+          window.open("https://www.instagram.com/team_nexters");
+          break;
+        }
       }
       return;
     },


### PR DESCRIPTION
# Summary
소스코드 내 하드코딩된 값을 수정하여, 타 채널처럼 인스타그램 링크가 ID로 간소화되어 표시되도록 수정했습니다.

`CONTACT` 항목들의 업데이트가 잦지는 않겠지만, 현재처럼 소스코드에 하드코딩한 값을 수정하는 방식을 개선할 필요가 있어 보입니다. (#38)

# Issue
#39 

---

<details open> <summary>스크린샷</summary>
<img width="1297" alt="스크린샷 2023-10-30 오후 6 20 10" src="https://github.com/Nexters/teamnexters.com/assets/87979147/72d2dd74-a150-4a5a-b0e3-48e7c32d2b9c">

</details>